### PR TITLE
Fix login page style and build

### DIFF
--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -21,7 +21,7 @@ header.banner .title {
 }
 
 /* set full screen background, but keep header above */
-.login‐page {
+.login-page {
   position: absolute;
   top: 0;
   left: 0;
@@ -44,7 +44,7 @@ header.banner {
 }
 
 /* Form card */
-.login‐card {
+.login-card {
   background: rgba(255,255,255,0.8);
   padding: 2rem;
   border-radius: 12px;
@@ -54,14 +54,14 @@ header.banner {
 }
 
 /* Headline */
-.login‐card h2 {
+.login-card h2 {
   margin-bottom: 1.5rem;
   color: #333;
   letter-spacing: 1px;
 }
 
 /* Inputs */
-.login‐card input {
+.login-card input {
   width: 100%;
   padding: 0.75rem 1rem;
   margin-bottom: 1rem;
@@ -73,7 +73,7 @@ header.banner {
 }
 
 /* Button */
-.login‐card button {
+.login-card button {
   background: #b71c1c;
   color: white;
   border: none;
@@ -83,18 +83,18 @@ header.banner {
   cursor: pointer;
   transition: background 0.2s;
 }
-.login‐card button:hover {
+.login-card button:hover {
   background: #7f0000;
 }
 
 /* Forgot link */
-.login‐card .forgot {
+.login-card .forgot {
   display: block;
   margin-top: 0.75rem;
   font-size: 0.875rem;
   color: #555;
   text-decoration: none;
 }
-.login‐card .forgot:hover {
+.login-card .forgot:hover {
   text-decoration: underline;
 }

--- a/apps/frontend/src/pages/Login.jsx
+++ b/apps/frontend/src/pages/Login.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useContext } from 'react';
 import axios from 'axios';
 import { AuthContext } from '../context/AuthContext.jsx';
-// import background from '../assets/background.jpeg';
 import '../index.css';
 
 export default function Login() {
@@ -22,15 +21,7 @@ export default function Login() {
   };
 
   return (
-    <div
-      className="login-page"
-      style={{
-        backgroundImage: `url(${background})`,
-        backgroundPosition: 'center',
-        backgroundSize: 'cover',
-        backgroundRepeat: 'no-repeat',
-      }}
-    >
+    <div className="login-page">
       <form className="login-card" onSubmit={handleSubmit}>
         <h2>LOGIN</h2>
         {error && (


### PR DESCRIPTION
## Summary
- remove undefined image import and inline styles
- fix CSS class names with standard hyphen

## Testing
- `npm --workspace apps/frontend run build`
- `npm test` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_6873f4b6e96c83299bcb01c86a641c0e